### PR TITLE
added clarification

### DIFF
--- a/wiki/Python_DeepLearning.md
+++ b/wiki/Python_DeepLearning.md
@@ -62,9 +62,10 @@ Choose Linux, Conda and choose the latest CUDA release (10.2 at the moment of wr
     
 **Step 5: JupyterHub and PyTorch**
 
-Let's say you have an Anaconda environment called `myenv`. To run things on JupyterHub, you need to install the ipykernel in that env:
+Let's say you have an Anaconda environment called `myenv`. To run things on JupyterHub, you need to install the ipykernel **from `myenv`**:
 
-    $ python -m ipykernel install --user --name myenv --display-name "Python (myenv)"
+1. ```$ conda activate myenv```
+2. ```$ python -m ipykernel install --user --name myenv --display-name "Python (myenv) ```
 
 This creates a new IPython kernel for your env and stores a kernel spec file in:
         


### PR DESCRIPTION
If a user follows the original guide and runs the "ipykernel install" from outside the environment, no error would appear because they would just be creating a new kernel with the same name as "myenv" despite it not actually being "myenv". This could lead to spending some time on debugging, especially for newbies (like me!). So this clarification should prevent that scenario.